### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DigSiNet
 
-This project implements a proof-of-concept environment to run Network Digital Twins (NDT). It primarily uses [containerlab](https://containerlab.dev/), but can also use other platforms to build, manage and monitor the twins. The concept uses multiple twins that can leverage different platforms, topologies and tools to specifically simulate and emulate only parts of the functionality of the real network. As they only partially share characteristics with the real network and multiple ones can be used an combined with each sibling using a different platform being well-suited for its purpose, they are called siblings instead of twins. 
+This project implements a proof-of-concept environment to run Network Digital Twins (NDT). It primarily uses [containerlab](https://containerlab.dev/), but can also use other platforms to build, manage and monitor the twins. The concept uses multiple twins that can leverage different platforms, topologies and tools to specifically simulate and emulate only parts of the functionality of the real network. As they only partially share characteristics with the real network and multiple ones can be used and combined with each sibling using a different platform being well-suited for its purpose, they are called siblings instead of twins. 
 
 # Concept
 
@@ -14,7 +14,7 @@ DigSiNet's architecture currently consists of the following components:
 * Apps
 * Queues
 
-Details regarding the architecture and its components are also described in the working-draft of the documentation [https://srieger1.github.io/digsinet/](https://srieger1.github.io/digsinet/) and were published and presented in our paper at NOMS 2024-2024 IEEE Network Operations and Management Symposium [https://ieeexplore.ieee.org/document/10575632](https://ieeexplore.ieee.org/document/10575632). As DigSiNet is currently being used as a proof-of-concept to run NDT experiments, its architecture and compoments are still subject to change, as can also be observed from the current development branches [https://github.com/srieger1/digsinet/branches](https://github.com/srieger1/digsinet/branches).
+Details regarding the architecture and its components are also described in the working-draft of the documentation [https://srieger1.github.io/digsinet/](https://srieger1.github.io/digsinet/) and were published and presented in our paper at NOMS 2024 – IEEE Network Operations and Management Symposium [https://ieeexplore.ieee.org/document/10575632](https://ieeexplore.ieee.org/document/10575632). As DigSiNet is currently being used as a proof-of-concept to run NDT experiments, its architecture and components are still subject to change, as can also be observed from the current development branches [https://github.com/srieger1/digsinet/branches](https://github.com/srieger1/digsinet/branches).
 
 # Requirements
 
@@ -33,7 +33,7 @@ Start DigSiNet by running:
 sudo ./digsinet.py
 ```
 
-The example starts digsinet.clab.yml by default to be used as the "real" network topology and two siblings. Each sibling can use an adapted topology and individual tools and platforms different from the real network. See digisinet.yml config file for examples and to change the setup.
+The example starts digsinet.clab.yml by default to be used as the "real" network topology and two siblings. Each sibling can use an adapted topology and individual tools and platforms different from the real network. See digsinet.yml config file for examples and to change the setup.
 
 Alternatively, a sample using [Nokia SR-Linux](https://containerlab.dev/manual/kinds/srl/) is provided in ```digsinet-srl.yml```. This config can be used by running:
 


### PR DESCRIPTION
## Summary
- fix small typos in the README

## Testing
- `pytest -q`
- `pip install flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_686848667290832284da6ed784b98e65